### PR TITLE
Fix `--keep-alive`

### DIFF
--- a/gitmopy/cli.py
+++ b/gitmopy/cli.py
@@ -27,6 +27,7 @@ from gitmopy.utils import (
     message_from_commit_dict,
     print_staged_files,
     resolve_path,
+    terminal_separator,
 )
 
 app = typer.Typer()
@@ -100,6 +101,7 @@ def should_commit_again(repo: Repo, remote: List[str]) -> bool:
         bool: Whether the user wants to continue or not.
     """
     gitmojis_setup()
+    print(terminal_separator())
     prompt_txt = (
         "\n🔄 [u]Ready to commit again[/u]. Press [b green]enter[/b green] "
         + "to commit again"

--- a/gitmopy/cli.py
+++ b/gitmopy/cli.py
@@ -111,6 +111,7 @@ def should_commit_again(repo: Repo, remote: List[str]) -> bool:
     print()
     remotes_diff = format_remotes_diff(repo)
     if remotes_diff:
+        print(remotes_diff)
         prompt_txt += ", [b dodger_blue2]p[/b dodger_blue2] to push and commit again,"
         if "does not have a branch" not in remotes_diff:
             prompt_txt += (
@@ -123,7 +124,6 @@ def should_commit_again(repo: Repo, remote: List[str]) -> bool:
     commit_again = typer.prompt(
         "", default="enter", show_default=False, prompt_suffix=""
     )
-    print("commit_again: ", commit_again)
     if remotes_diff:
         if commit_again in {"p", "s"}:
             if commit_again == "s":

--- a/gitmopy/cli.py
+++ b/gitmopy/cli.py
@@ -121,6 +121,7 @@ def should_commit_again(repo: Repo, remote: List[str]) -> bool:
     commit_again = typer.prompt(
         "", default="enter", show_default=False, prompt_suffix=""
     )
+    print("commit_again: ", commit_again)
     if remotes_diff:
         if commit_again == "s":
             pull_cli(repo, remote)
@@ -333,7 +334,7 @@ def commit(
                     continue
                 elif not to_add:
                     print("[yellow]No file selected, nothing to commit.[/yellow]")
-                    if should_commit_again(repo, remote):
+                    if keep_alive and should_commit_again(repo, remote):
                         # user wants to commit again: start over
                         continue
                     # user wants to stop: break loop
@@ -383,8 +384,12 @@ def commit(
 
         if push:
             push_cli(repo, remote)
-        if not keep_alive or not should_commit_again(repo, remote):
-            break
+        if print("\nLast chance\n") or (
+            keep_alive and should_commit_again(repo, remote)
+        ):
+            print("continueing")
+            continue
+        break
 
     print("\nDone 🥳\n")
 

--- a/gitmopy/cli.py
+++ b/gitmopy/cli.py
@@ -127,9 +127,11 @@ def should_commit_again(repo: Repo, remote: List[str]) -> bool:
             pull_cli(repo, remote)
         if commit_again in {"p", "s"}:
             push_cli(repo, remote)
+        print("internal recusion should_commit_again ")
         return should_commit_again(repo, remote)
 
     commit_again = commit_again != "q"
+    print("commit_again: ", commit_again)
 
     if commit_again:
         print()

--- a/gitmopy/cli.py
+++ b/gitmopy/cli.py
@@ -101,9 +101,10 @@ def should_commit_again(repo: Repo, remote: List[str]) -> bool:
         bool: Whether the user wants to continue or not.
     """
     gitmojis_setup()
+    print()
     print(terminal_separator())
     prompt_txt = (
-        "\n🔄 [u]Ready to commit again[/u]. Press [b green]enter[/b green] "
+        "🔄 [u]Ready to commit again[/u]. Press [b green]enter[/b green] "
         + "to commit again"
     )
 

--- a/gitmopy/cli.py
+++ b/gitmopy/cli.py
@@ -108,7 +108,6 @@ def should_commit_again(repo: Repo, remote: List[str]) -> bool:
     print()
     remotes_diff = format_remotes_diff(repo)
     if remotes_diff:
-        print(remotes_diff)
         prompt_txt += ", [b dodger_blue2]p[/b dodger_blue2] to push and commit again,"
         if "does not have a branch" not in remotes_diff:
             prompt_txt += (
@@ -123,15 +122,13 @@ def should_commit_again(repo: Repo, remote: List[str]) -> bool:
     )
     print("commit_again: ", commit_again)
     if remotes_diff:
-        if commit_again == "s":
-            pull_cli(repo, remote)
         if commit_again in {"p", "s"}:
+            if commit_again == "s":
+                pull_cli(repo, remote)
             push_cli(repo, remote)
-        print("internal recusion should_commit_again ")
-        return should_commit_again(repo, remote)
+            return should_commit_again(repo, remote)
 
     commit_again = commit_again != "q"
-    print("commit_again: ", commit_again)
 
     if commit_again:
         print()
@@ -386,11 +383,11 @@ def commit(
 
         if push:
             push_cli(repo, remote)
-        if print("\nLast chance\n") or (
-            keep_alive and should_commit_again(repo, remote)
-        ):
-            print("continueing")
+
+        if keep_alive and should_commit_again(repo, remote):
+            # user wants to commit again
             continue
+        # stop here
         break
 
     print("\nDone 🥳\n")

--- a/gitmopy/prompt.py
+++ b/gitmopy/prompt.py
@@ -19,7 +19,7 @@ from gitmopy.utils import (
     load_config,
     safe_capitalize,
     save_config,
-    separator,
+    choice_separator,
 )
 
 
@@ -222,12 +222,12 @@ def git_add_prompt(status: Dict[str, List[str]]) -> List[str]:
     """
     choices = []
     if len(status["unstaged"]) > 0:
-        choices.append(separator("Unstaged files"))
+        choices.append(choice_separator("Unstaged files"))
     for s in status["unstaged"]:
         choices.append(Choice(s, s, True))
 
     if len(status["untracked"]) > 0:
-        choices.append(separator("Untracked files"))
+        choices.append(choice_separator("Untracked files"))
     for s in status["untracked"]:
         choices.append(Choice(s, s, True))
 

--- a/gitmopy/utils.py
+++ b/gitmopy/utils.py
@@ -3,6 +3,7 @@ Utility functions and constants for ``gitmopy``.
 """
 from os.path import expandvars
 from pathlib import Path
+from shutil import get_terminal_size
 from typing import Dict, List, Union
 
 import typer
@@ -194,6 +195,18 @@ def safe_capitalize(s):
     if len(s) == 1:
         return s.upper()
     return s[0].upper() + s[1:]
+
+
+def terminal_separator(margin=10):
+    """
+    Create a separator for the terminal.
+
+    Returns:
+        str: Terminal separator
+    """
+    total = get_terminal_size().columns
+    sep = "―" * (total - 2 * margin)
+    return f"{' ' * margin}{sep}{' ' * margin}"
 
 
 # https://github.com/carloscuesta/gitmoji/blob/master/packages/gitmojis/src/gitmojis.json

--- a/gitmopy/utils.py
+++ b/gitmopy/utils.py
@@ -205,7 +205,7 @@ def terminal_separator(margin=10):
         str: Terminal separator
     """
     total = get_terminal_size().columns
-    sep = "―" * (total - 2 * margin)
+    sep = "─" * (total - 2 * margin)
     return f"{' ' * margin}{sep}{' ' * margin}"
 
 

--- a/gitmopy/utils.py
+++ b/gitmopy/utils.py
@@ -150,7 +150,7 @@ def message_from_commit_dict(commit_dict: Dict[str, str]) -> str:
     return message.strip()
 
 
-def separator(title: str = "", width: int = 30, sep: str = "-") -> Separator:
+def choice_separator(title: str = "", width: int = 30, sep: str = "─") -> Separator:
     """
     Create an InquirerPy separator with a title.
 
@@ -158,7 +158,7 @@ def separator(title: str = "", width: int = 30, sep: str = "-") -> Separator:
         title (str, optional): Title in-between separator characters.
             Defaults to ``""``.
         width (int, optional): Total length of sperator line. Defaults to 30.
-        sep (str, optional): Character to use around the ``title``. Defaults to ``"-"``.
+        sep (str, optional): Character to use around the ``title``. Defaults to ``"─"``.
 
     Returns:
         Separator: _description_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gitmopy"
-version = "0.3.2"
+version = "0.3.3"
 description = "A python command-line for gitmoji"
 authors = ["vict0rsch <vsch@pm.me>"]
 license = "MIT"


### PR DESCRIPTION
Fix an indentation bug that would prevent the main `commit` loop from going back to to committing, but rather make `should_commit_again` stay locked in (manually-triggered) recursive calls